### PR TITLE
Remove momentum-cpp dep from pymomentum

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,7 +84,6 @@ outputs:
         - pybind11
         - python
       host:
-        - {{ pin_subpackage('momentum-cpp', exact=True) }}
         - ceres-solver
         - cli11
         - dispenso
@@ -108,7 +107,6 @@ outputs:
         - pytorch
         - numpy
       run:
-        - {{ pin_subpackage('momentum-cpp', exact=True) }}
         - dispenso
         - gflags
         - libdeflate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 77f9e8a260d19cce7e3ce8b02367da2e5fa04af2e27dd4a508b24229b5784563
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
 
 outputs:


### PR DESCRIPTION
`pymomentum` depends on static libraries of momentum, so it doesn't need to depend on `momentum-cpp` (i.e., shared libraries).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
