### PR TITLE
Enable linux-aarch64 CPU builds

### DIFF
--- a/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNone.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.31.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -34,6 +34,12 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_cuda_compiler_versionNone
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     steps:
 
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_cuda_compiler_versionNone</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=22772&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/momentum-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_versionNone" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=22772&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,6 +7,7 @@ azure:
 bot:
   automerge: true
 build_platform:
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   error_overlinking: true

--- a/pixi.toml
+++ b/pixi.toml
@@ -44,6 +44,15 @@ description = "Debug momentum-feedstock with variant linux_64_cuda_compiler_vers
 [tasks."inspect-linux_64_cuda_compiler_versionNone"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_cuda_compiler_versionNone.yaml"
 description = "List contents of momentum-feedstock packages built for variant linux_64_cuda_compiler_versionNone"
+[tasks."build-linux_aarch64_cuda_compiler_versionNone"]
+cmd = "conda-build build recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNone.yaml --suppress-variables --clobber-file .ci_support/clobber_linux_aarch64_cuda_compiler_versionNone.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_versionNone directly (without setup scripts)"
+[tasks."debug-linux_aarch64_cuda_compiler_versionNone"]
+cmd = "conda-build debug recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNone.yaml"
+description = "Debug momentum-feedstock with variant linux_aarch64_cuda_compiler_versionNone directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_versionNone"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNone.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_versionNone"
 [tasks."build-osx_64_"]
 cmd = "conda-build build recipe -m .ci_support/osx_64_.yaml --suppress-variables --clobber-file .ci_support/clobber_osx_64_.yaml"
 description = "Build momentum-feedstock with variant osx_64_ directly (without setup scripts)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -231,6 +231,13 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("pymomentum", exact=True) }}
+    test:
+      imports:
+        - pymomentum.axel
+      commands:
+        - pip check
+      requires:
+        - pip
 
   - name: momentum
     build:
@@ -241,6 +248,14 @@ outputs:
         - {{ pin_subpackage('momentum-cpp', exact=True) }}
         - {{ pin_subpackage('pymomentum', exact=True) }}
         - python
+    test:
+      imports:
+        - pymomentum.axel
+      commands:
+        - hello_world
+        - pip check
+      requires:
+        - pip
 
 about:
   home: https://facebookresearch.github.io/momentum/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ build:
   number: 0
   # Skip Python < 3.12
   skip: true  # [py<312]
+  # Enable Linux aarch64 for CPU builds first; CUDA aarch64 needs a separate
+  # dependency audit and is not part of this platform-expansion pass.
+  skip: true  # [cuda_compiler_version != "None" and aarch64]
 
 outputs:
   - name: momentum-cpp

--- a/recipe/run_test_cpp.bat
+++ b/recipe/run_test_cpp.bat
@@ -9,3 +9,6 @@ if errorlevel 1 exit 1
 
 cmake --build tests/build --parallel --config Release
 if errorlevel 1 exit 1
+
+ctest --test-dir tests/build --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipe/run_test_cpp.sh
+++ b/recipe/run_test_cpp.sh
@@ -10,3 +10,4 @@ cmake tests \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build tests/build --parallel
+ctest --test-dir tests/build --output-on-failure

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3)
 
-project(momentum_consumer LANGUAGES CXX)
+project(momentum_consumer LANGUAGES C CXX)
 
 include(CTest)
 

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.16.3)
 
-project(momentum)
+project(momentum_consumer LANGUAGES CXX)
+
+include(CTest)
 
 find_package(momentum CONFIG REQUIRED)
-add_executable(hello_world main.cpp)
-target_link_libraries(hello_world PRIVATE momentum::math)
+add_executable(momentum_consumer main.cpp)
+target_link_libraries(momentum_consumer PRIVATE momentum::math)
+add_test(NAME momentum_consumer COMMAND momentum_consumer)

--- a/recipe/tests/main.cpp
+++ b/recipe/tests/main.cpp
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 #include <momentum/math/mesh.h>
 
 using namespace momentum;


### PR DESCRIPTION
This draft PR enables linux-aarch64 CPU builds for momentum while leaving CUDA-on-aarch64 out of scope.

Changes:
- adds `linux_aarch64: linux_64` to `build_platform`
- skips `cuda_compiler_version != "None"` on aarch64, since the CUDA dependency path needs a separate audit
- rerenders with conda-smithy, producing the linux-aarch64 CPU CI config only

Validation:
- `git diff --check upstream/main..HEAD`
- `conda-smithy recipe-lint --conda-forge recipe` (existing suggestions remain for wrapper outputs `pymomentum-gpu` and `momentum`)
- isolated `conda-build --output -m .ci_support/linux_aarch64_cuda_compiler_versionNone.yaml --croot <tmp> -c conda-forge`, which solved `momentum-cpp`, `pymomentum`, `pymomentum-cpu`, and aggregate `momentum` for linux-aarch64 across Python 3.12, 3.13, and 3.14

I am keeping this draft until the emulated linux-aarch64 CI build confirms the package actually builds and tests on conda-forge infrastructure.