### PR TITLE
Add pymomentum-core split package

### DIFF
--- a/recipe/bld_py_core.bat
+++ b/recipe/bld_py_core.bat
@@ -1,0 +1,17 @@
+@echo on
+setlocal EnableExtensions EnableDelayedExpansion
+
+cd /d %SRC_DIR%
+
+set CMAKE_ARGS=%CMAKE_ARGS% ^
+    -DMOMENTUM_BUILD_IO_USD=OFF ^
+    -DMOMENTUM_BUILD_RENDERER=OFF ^
+    -DMOMENTUM_BUILD_RERUN=OFF ^
+    -DMOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS=OFF ^
+    -DMOMENTUM_BUILD_TESTING=OFF ^
+    -DMOMENTUM_ENABLE_SIMD=OFF ^
+    -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON ^
+    -DMOMENTUM_USE_SYSTEM_PYBIND11=ON
+
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/recipe/build_py_core.sh
+++ b/recipe/build_py_core.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -exo pipefail
+
+if [[ "${target_platform}" == osx-* ]]; then
+  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+# Workaround for fx/gltf.h:70:13: error: narrowing conversion of '-1' from 'int' to 'char' [-Wnarrowing]
+if [[ "${target_platform}" == *aarch64 || "${target_platform}" == *ppc64le ]]; then
+  CXXFLAGS="${CXXFLAGS} -Wno-narrowing"
+fi
+
+export CMAKE_ARGS="$CMAKE_ARGS \
+    -DMOMENTUM_BUILD_IO_USD=OFF \
+    -DMOMENTUM_BUILD_RENDERER=OFF \
+    -DMOMENTUM_BUILD_RERUN=OFF \
+    -DMOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS=OFF \
+    -DMOMENTUM_BUILD_TESTING=OFF \
+    -DMOMENTUM_ENABLE_SIMD=OFF \
+    -DMOMENTUM_USE_SYSTEM_PYBIND11=OFF"
+
+if [[ "${target_platform}" != "${build_platform}" ]]; then
+  export CMAKE_ARGS="$CMAKE_ARGS -DMOMENTUM_USE_SYSTEM_GOOGLETEST=OFF"
+else
+  export CMAKE_ARGS="$CMAKE_ARGS -DMOMENTUM_USE_SYSTEM_GOOGLETEST=ON"
+fi
+
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,12 @@ package:
 source:
   - url: https://github.com/facebookresearch/momentum/archive/v{{ version }}.tar.gz
     sha256: ab8d7fccd7d915bc403a7afa3ab2d03b1d07eae5f66b9dc4b75b6857514e5f4a
+    patches:
+      - patches/0003-Make-native-rerun-support-optional.patch
+      - patches/0004-Make-PyMomentum-Torch-extensions-optional.patch
 
 build:
-  number: 0
+  number: 1
   # Skip Python < 3.12
   skip: true  # [py<312]
 
@@ -44,16 +47,16 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
       host:
-        - ceres-solver
+        - ceres-solver * cpu*
         - cli11
         - dispenso
-        - drjit-cpp
+        - drjit-cpp * cpu*
         - eigen
         - ezc3d
         - fmt
         - fx-gltf
         - indicators
-        - kokkos
+        - kokkos * h*
         - librerun-sdk
         - ms-gsl
         - nlohmann_json
@@ -65,15 +68,16 @@ outputs:
         - tbb-devel  # [not win]
         - urdfdom
       run:
-        - ceres-solver
+        - ceres-solver * cpu*
         - cli11
         - dispenso
-        - drjit-cpp
+        - drjit-cpp * cpu*
         - ezc3d
         - fx-gltf
         - indicators
         - libabseil  # [osx]
         - librerun-sdk
+        - kokkos * h*
         - gflags
         - libdeflate
         - ms-gsl
@@ -136,7 +140,8 @@ outputs:
         - pip
         - pybind11-abi 11
         - python
-        - pytorch
+        - pytorch * cpu*                              # [cuda_compiler_version == "None"]
+        - pytorch                                     # [cuda_compiler_version != "None"]
         - scikit-build-core >=0.11
       host:
         # GPU requirements
@@ -151,16 +156,18 @@ outputs:
         - nvtx-c                                        # [cuda_compiler_version != "None"]
         - kokkos * *cuda*                               # [cuda_compiler_version != "None"]
         # other requirements
-        - ceres-solver
+        - ceres-solver * cpu*                         # [cuda_compiler_version == "None"]
+        - ceres-solver                                 # [cuda_compiler_version != "None"]
         - cli11
         - dispenso
-        - drjit-cpp
+        - drjit-cpp * cpu*                             # [cuda_compiler_version == "None"]
+        - drjit-cpp                                    # [cuda_compiler_version != "None"]
         - eigen
         - ezc3d
         - fmt
         - fx-gltf
         - indicators
-        - kokkos
+        - kokkos * h*                                  # [cuda_compiler_version == "None"]
         - librerun-sdk
         - ms-gsl
         - nlohmann_json
@@ -170,8 +177,10 @@ outputs:
         - pip
         - pytest
         - python
-        - pytorch
-        - libtorch  # [unix]  # Provides torch/torch.h C++ headers
+        - pytorch * cpu*                              # [cuda_compiler_version == "None"]
+        - pytorch                                     # [cuda_compiler_version != "None"]
+        - libtorch * cpu*                             # [unix and cuda_compiler_version == "None"]  # Provides torch/torch.h C++ headers
+        - libtorch                                    # [unix and cuda_compiler_version != "None"]  # Provides torch/torch.h C++ headers
         - re2
         - scikit-build-core >=0.11
         - spdlog
@@ -184,6 +193,9 @@ outputs:
         - cuda-nvrtc                                    # [cuda_compiler_version != "None"]
         # Kokkos CUDA variant needed for geometry module on CUDA builds
         - kokkos * *cuda*                               # [cuda_compiler_version != "None"]
+        - kokkos * h*                                   # [cuda_compiler_version == "None"]
+        - ceres-solver * cpu*                           # [cuda_compiler_version == "None"]
+        - drjit-cpp * cpu*                              # [cuda_compiler_version == "None"]
         - ezc3d
         - dispenso
         - gflags
@@ -196,6 +208,8 @@ outputs:
         - re2
         - spdlog
         - tbb  # [linux]
+      run_constrained:
+        - pymomentum-core <0.0a0
     test:
       imports:
         - pymomentum.axel
@@ -213,6 +227,114 @@ outputs:
         - pymomentum.torch.character  # [not (win and cuda_compiler_version != "None")]
         - pymomentum.trs
       commands:
+        - pip list
+        - pip check
+      requires:
+        - pip
+
+  - name: pymomentum-core
+    script: build_py_core.sh  # [unix]
+    script: bld_py_core.bat  # [win]
+    build:
+      skip:
+        - true  # [cuda_compiler_version != "None"]
+      string: cpu_py{{ CONDA_PY }}_pt{{ pytorch | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      # Core lists runtime deps explicitly so host run_exports do not pull
+      # renderer/viewer transitive deps back into the trimmed package.
+      ignore_run_exports_from:
+        - ceres-solver
+        - cli11
+        - dispenso
+        - drjit-cpp
+        - eigen
+        - ezc3d
+        - fmt
+        - fx-gltf
+        - indicators
+        - ms-gsl
+        - nlohmann_json
+        - openfbx
+        - re2
+        - spdlog
+        - urdfdom
+        - zlib
+      ignore_run_exports:
+        - ceres-solver
+        - drjit-cpp
+        - eigen
+        - fmt
+        - indicators
+        - openfbx
+        - urdfdom_headers
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
+        - cmake
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+        - gtest
+        - indicators
+        - libboost-devel
+        - make
+        - ninja
+        - pip
+        - pybind11-abi 11
+        - python
+        - scikit-build-core >=0.11
+      host:
+        - ceres-solver * cpu*
+        - cli11
+        - dispenso
+        - drjit-cpp * cpu*
+        - eigen
+        - ezc3d
+        - fmt
+        - fx-gltf
+        - indicators
+        - ms-gsl
+        - nlohmann_json
+        - numpy
+        - openfbx
+        - pip
+        - pytest
+        - python
+        - re2
+        - scikit-build-core >=0.11
+        - spdlog
+        - urdfdom
+        - zlib
+      run:
+        - ceres-solver * cpu*
+        - dispenso
+        - drjit-cpp * cpu*
+        - ezc3d
+        - libabseil  # [osx]
+        - libdeflate
+        - libre2-11
+        - numpy
+        - python
+        - pytorch
+        - re2
+        - spdlog
+        - urdfdom
+      run_constrained:
+        - pymomentum <0.0a0
+        - pymomentum-cpu <0.0a0
+        - pymomentum-gpu <0.0a0
+    test:
+      imports:
+        - pymomentum.backend
+        - pymomentum.geometry
+        - pymomentum.marker_tracking
+        - pymomentum.quaternion
+        - pymomentum.rerun_vis
+        - pymomentum.skel_state
+        - pymomentum.solver2
+        - pymomentum.torch.character
+        - pymomentum.trs
+        - pymomentum.viser_vis
+      commands:
+        - python -c "import importlib.util; assert importlib.util.find_spec('pymomentum.axel') is None; assert importlib.util.find_spec('pymomentum.diff_geometry') is None; assert importlib.util.find_spec('pymomentum.solver') is None"
         - pip list
         - pip check
       requires:

--- a/recipe/patches/0003-Make-native-rerun-support-optional.patch
+++ b/recipe/patches/0003-Make-native-rerun-support-optional.patch
@@ -1,0 +1,249 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 886749b..90b74b4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,6 +84,7 @@ mt_option(MOMENTUM_BUILD_PYMOMENTUM "Build Python binding" OFF)
+ mt_option(MOMENTUM_BUILD_TESTING "Enable building tests" OFF)
+ mt_option(MOMENTUM_BUILD_EXAMPLES "Enable building examples" OFF)
+ mt_option(MOMENTUM_BUILD_RENDERER "Build renderer and rasterizer" ON)
++mt_option(MOMENTUM_BUILD_RERUN "Build native Rerun C++ visualization support" ON)
+ mt_option(MOMENTUM_ENABLE_PROFILING "Enable building with profiling annotations" OFF)
+ mt_option(MOMENTUM_ENABLE_SIMD "Enable building with SIMD instructions" ON)
+ mt_option(MOMENTUM_INSTALL_EXAMPLES "Install examples" OFF)
+@@ -146,26 +147,28 @@ if(MOMENTUM_BUILD_RENDERER)
+   FetchContent_MakeAvailable(mdspan)
+ endif()
+ 
+-if(MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK)
+-  find_package(rerun_sdk CONFIG REQUIRED)
+-else()
+-  include(FetchContent)
+-  FetchContent_Declare(rerun_sdk
+-    URL https://github.com/rerun-io/rerun/releases/download/0.28.2/rerun_cpp_sdk.zip
+-  )
+-  FetchContent_MakeAvailable(rerun_sdk)
+-endif()
+-
+-# Workaround for Arrow build failure in cibuildwheel
+-if(TARGET arrow_shared)
+-  # If arrow_shared is already defined (e.g. by rerun_sdk), ensure we don't try to build it again
+-  # or if it's an imported target, we are good.
+-elseif(TARGET Arrow::arrow_shared)
+-  # System arrow found
+-else()
+-  # If rerun_sdk didn't provide arrow, we might need to find it
++if(MOMENTUM_BUILD_RERUN)
+   if(MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK)
+-    find_package(Arrow CONFIG REQUIRED)
++    find_package(rerun_sdk CONFIG REQUIRED)
++  else()
++    include(FetchContent)
++    FetchContent_Declare(rerun_sdk
++      URL https://github.com/rerun-io/rerun/releases/download/0.28.2/rerun_cpp_sdk.zip
++    )
++    FetchContent_MakeAvailable(rerun_sdk)
++  endif()
++
++  # Workaround for Arrow build failure in cibuildwheel
++  if(TARGET arrow_shared)
++    # If arrow_shared is already defined (e.g. by rerun_sdk), ensure we don't try to build it again
++    # or if it's an imported target, we are good.
++  elseif(TARGET Arrow::arrow_shared)
++    # System arrow found
++  else()
++    # If rerun_sdk didn't provide arrow, we might need to find it
++    if(MOMENTUM_USE_SYSTEM_RERUN_CPP_SDK)
++      find_package(Arrow CONFIG REQUIRED)
++    endif()
+   endif()
+ endif()
+ 
+@@ -679,28 +682,30 @@ if(MOMENTUM_BUILD_RENDERER)
+   )
+ endif()
+ 
+-mt_library(
+-  NAME rerun_eigen_adapters
+-  HEADERS_VARS
+-    rerun_eigen_adapters_public_headers
+-  PUBLIC_LINK_LIBRARIES
+-    Eigen3::Eigen
+-    rerun_sdk
+-)
++if(MOMENTUM_BUILD_RERUN)
++  mt_library(
++    NAME rerun_eigen_adapters
++    HEADERS_VARS
++      rerun_eigen_adapters_public_headers
++    PUBLIC_LINK_LIBRARIES
++      Eigen3::Eigen
++      rerun_sdk
++  )
+ 
+-mt_library(
+-  NAME rerun
+-  HEADERS_VARS
+-    rerun_public_headers
+-  SOURCES_VARS
+-    rerun_sources
+-  PUBLIC_LINK_LIBRARIES
+-    character
+-    rerun_sdk
+-  PRIVATE_LINK_LIBRARIES
+-    rerun_eigen_adapters
+-    axel
+-)
++  mt_library(
++    NAME rerun
++    HEADERS_VARS
++      rerun_public_headers
++    SOURCES_VARS
++      rerun_sources
++    PUBLIC_LINK_LIBRARIES
++      character
++      rerun_sdk
++    PRIVATE_LINK_LIBRARIES
++      rerun_eigen_adapters
++      axel
++  )
++endif()
+ 
+ #===============================================================================
+ # Tests
+@@ -1005,14 +1010,16 @@ if(MOMENTUM_BUILD_TESTING)
+       marker_tracker
+   )
+ 
+-  mt_test(
+-    NAME rerun_test
+-    SOURCES_VARS rerun_test_sources
+-    LINK_LIBRARIES
+-      character_test_helpers
+-      rerun
+-      rerun_eigen_adapters
+-  )
++  if(MOMENTUM_BUILD_RERUN)
++    mt_test(
++      NAME rerun_test
++      SOURCES_VARS rerun_test_sources
++      LINK_LIBRARIES
++        character_test_helpers
++        rerun
++        rerun_eigen_adapters
++    )
++  endif()
+ endif()
+ 
+ #===============================================================================
+@@ -1036,55 +1043,57 @@ if(MOMENTUM_BUILD_EXAMPLES)
+       CLI11::CLI11
+   )
+ 
+-  mt_executable(
+-    NAME glb_viewer
+-    SOURCES_VARS glb_viewer_sources
+-    LINK_LIBRARIES
+-      io_gltf
+-      rerun
+-      CLI11::CLI11
+-      rerun_sdk
+-  )
++  if(MOMENTUM_BUILD_RERUN)
++    mt_executable(
++      NAME glb_viewer
++      SOURCES_VARS glb_viewer_sources
++      LINK_LIBRARIES
++        io_gltf
++        rerun
++        CLI11::CLI11
++        rerun_sdk
++    )
+ 
+-  mt_executable(
+-    NAME fbx_viewer
+-    SOURCES_VARS fbx_viewer_sources
+-    LINK_LIBRARIES
+-      io_fbx
+-      rerun
+-      CLI11::CLI11
+-      rerun_sdk
+-  )
++    mt_executable(
++      NAME fbx_viewer
++      SOURCES_VARS fbx_viewer_sources
++      LINK_LIBRARIES
++        io_fbx
++        rerun
++        CLI11::CLI11
++        rerun_sdk
++    )
+ 
+-  mt_executable(
+-    NAME c3d_viewer
+-    SOURCES_VARS c3d_viewer_sources
+-    LINK_LIBRARIES
+-      io_marker
+-      rerun
+-      CLI11::CLI11
+-      rerun_sdk
+-  )
++    mt_executable(
++      NAME c3d_viewer
++      SOURCES_VARS c3d_viewer_sources
++      LINK_LIBRARIES
++        io_marker
++        rerun
++        CLI11::CLI11
++        rerun_sdk
++    )
+ 
+-  mt_executable(
+-    NAME urdf_viewer
+-    SOURCES_VARS urdf_viewer_sources
+-    LINK_LIBRARIES
+-      io_urdf
+-      rerun
+-      CLI11::CLI11
+-      rerun_sdk
+-  )
++    mt_executable(
++      NAME urdf_viewer
++      SOURCES_VARS urdf_viewer_sources
++      LINK_LIBRARIES
++        io_urdf
++        rerun
++        CLI11::CLI11
++        rerun_sdk
++    )
+ 
+-  mt_executable(
+-    NAME bvh_viewer
+-    SOURCES_VARS bvh_viewer_sources
+-    LINK_LIBRARIES
+-      io_bvh
+-      rerun
+-      CLI11::CLI11
+-      rerun_sdk
+-  )
++    mt_executable(
++      NAME bvh_viewer
++      SOURCES_VARS bvh_viewer_sources
++      LINK_LIBRARIES
++        io_bvh
++        rerun
++        CLI11::CLI11
++        rerun_sdk
++    )
++  endif()
+ 
+   mt_executable(
+     NAME animate_shapes
+@@ -1125,7 +1134,7 @@ if(MOMENTUM_BUILD_EXAMPLES)
+       CLI11::CLI11
+   )
+ 
+-  if(MOMENTUM_BUILD_IO_USD)
++  if(MOMENTUM_BUILD_IO_USD AND MOMENTUM_BUILD_RERUN)
+     mt_executable(
+       NAME usd_viewer
+       SOURCES_VARS usd_viewer_sources

--- a/recipe/patches/0004-Make-PyMomentum-Torch-extensions-optional.patch
+++ b/recipe/patches/0004-Make-PyMomentum-Torch-extensions-optional.patch
@@ -1,0 +1,458 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -82,6 +82,7 @@
+ mt_option(MOMENTUM_BUILD_IO_USD "Build USD I/O support" OFF)
+ mt_option(MOMENTUM_BUILD_PYMOMENTUM "Build Python binding" OFF)
+ mt_option(MOMENTUM_BUILD_TESTING "Enable building tests" OFF)
++mt_option(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS "Build PyMomentum modules that link against Torch C++ libraries" ON)
+ mt_option(MOMENTUM_BUILD_EXAMPLES "Enable building examples" OFF)
+ mt_option(MOMENTUM_BUILD_RENDERER "Build renderer and rasterizer" ON)
+ mt_option(MOMENTUM_BUILD_RERUN "Build native Rerun C++ visualization support" ON)
+--- a/pymomentum/CMakeLists.txt
++++ b/pymomentum/CMakeLists.txt
+@@ -7,51 +7,58 @@
+ # Find dependencies
+ #===============================================================================
+ 
++if(NOT DEFINED MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++  set(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS ON)
++endif()
++
+ if(NOT DEFINED ENV{CONDA_PREFIX})
+   message(STATUS
+     "CONDA_PREFIX is not set. Building without Conda/Pixi environment."
+   )
+ endif()
+ 
+-# Determine torch base path based on build environment and platform
+-# Use CONDA_PREFIX for Unix conda-build, use site-packages for PyPI or Windows
+-if(DEFINED ENV{CONDA_BUILD} AND NOT WIN32)
+-  # Unix conda-build - use CONDA_PREFIX
+-  set(libtorch_base_path $ENV{CONDA_PREFIX})
+-else()
+-  # Windows or PyPI - use site-packages/torch
+-  if(NOT DEFINED Python3_SITELIB)
+-    execute_process(
+-      COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_path('purelib'))"
+-      OUTPUT_VARIABLE Python3_SITELIB
+-      OUTPUT_STRIP_TRAILING_WHITESPACE
++if(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++  # Determine torch base path based on build environment and platform
++  # Use CONDA_PREFIX for Unix conda-build, use site-packages for PyPI or Windows
++  if(DEFINED ENV{CONDA_BUILD} AND NOT WIN32)
++    # Unix conda-build - use CONDA_PREFIX
++    set(libtorch_base_path $ENV{CONDA_PREFIX})
++  else()
++    # Windows or PyPI - use site-packages/torch
++    if(NOT DEFINED Python3_SITELIB)
++      execute_process(
++        COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_path('purelib'))"
++        OUTPUT_VARIABLE Python3_SITELIB
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++      )
++    endif()
++    set(libtorch_base_path ${Python3_SITELIB}/torch)
++  endif()
++
++  if(NOT EXISTS "${libtorch_base_path}")
++    message(FATAL_ERROR
++      "PyTorch not found in the expected location: ${libtorch_base_path}.\n"
++      "Please ensure PyTorch is installed in your Conda/Pixi environment, "
++      "or configure with -DMOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS=OFF."
+     )
+   endif()
+-  set(libtorch_base_path ${Python3_SITELIB}/torch)
+-endif()
+ 
+-if(NOT EXISTS "${libtorch_base_path}")
+-  message(FATAL_ERROR
+-    "PyTorch not found in the expected location: ${libtorch_base_path}.\n"
+-    "Please ensure PyTorch is installed in your Conda/Pixi environment."
++  # Try both locations for CMake files (conda and PyPI have different structures)
++  find_package(ATen CONFIG REQUIRED HINTS
++    ${libtorch_base_path}/share/cmake/ATen
++    ${libtorch_base_path}
++  )
++  find_package(Torch CONFIG REQUIRED HINTS
++    ${libtorch_base_path}/share/cmake/Torch
++    ${libtorch_base_path}
++  )
++  find_library(torch_python
++    NAMES torch_python
++    HINTS ${libtorch_base_path}/lib/
++    REQUIRED
+   )
+ endif()
+ 
+-# Try both locations for CMake files (conda and PyPI have different structures)
+-find_package(ATen CONFIG REQUIRED HINTS
+-  ${libtorch_base_path}/share/cmake/ATen
+-  ${libtorch_base_path}
+-)
+-find_package(Torch CONFIG REQUIRED HINTS
+-  ${libtorch_base_path}/share/cmake/Torch
+-  ${libtorch_base_path}
+-)
+-find_library(torch_python
+-  NAMES torch_python
+-  HINTS ${libtorch_base_path}/lib/
+-  REQUIRED
+-)
+-
+ #===============================================================================
+ # Find build dependencies
+ #===============================================================================
+@@ -74,36 +81,38 @@
+ # Build PyMomentum
+ #===============================================================================
+ 
+-# TorchBridge INTERFACE library for OSS builds
+-set(TORCH_BRIDGE_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/torch_bridge_include)
+-file(MAKE_DIRECTORY ${TORCH_BRIDGE_INCLUDE_DIR}/pymomentum)
+-configure_file(
+-  ${CMAKE_CURRENT_SOURCE_DIR}/oss/torch_bridge.h.in
+-  ${TORCH_BRIDGE_INCLUDE_DIR}/pymomentum/torch_bridge.h
+-  COPYONLY
+-)
++if(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++  # TorchBridge INTERFACE library for OSS builds
++  set(TORCH_BRIDGE_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/torch_bridge_include)
++  file(MAKE_DIRECTORY ${TORCH_BRIDGE_INCLUDE_DIR}/pymomentum)
++  configure_file(
++    ${CMAKE_CURRENT_SOURCE_DIR}/oss/torch_bridge.h.in
++    ${TORCH_BRIDGE_INCLUDE_DIR}/pymomentum/torch_bridge.h
++    COPYONLY
++  )
+ 
+-add_library(torch_bridge INTERFACE)
+-target_include_directories(torch_bridge INTERFACE ${TORCH_BRIDGE_INCLUDE_DIR})
++  add_library(torch_bridge INTERFACE)
++  target_include_directories(torch_bridge INTERFACE ${TORCH_BRIDGE_INCLUDE_DIR})
+ 
+-mt_library(
+-  NAME tensor_utility
+-  PYMOMENTUM_HEADERS_VARS tensor_utility_public_headers
+-  PYMOMENTUM_SOURCES_VARS tensor_utility_sources
+-  PUBLIC_INCLUDE_DIRECTORIES
+-    ${Python3_INCLUDE_DIRS}
+-    ${TORCH_INCLUDE_DIRS}
+-  PUBLIC_LINK_LIBRARIES
+-    Eigen3::Eigen
+-    pybind11::pybind11_headers
+-    Python3::Module
+-    ${TORCH_LIBRARIES}
+-  PRIVATE_LINK_LIBRARIES
+-    momentum
+-  PUBLIC_COMPILE_OPTIONS
+-    ${TORCH_CXX_FLAGS}
+-  NO_INSTALL
+-)
++  mt_library(
++    NAME tensor_utility
++    PYMOMENTUM_HEADERS_VARS tensor_utility_public_headers
++    PYMOMENTUM_SOURCES_VARS tensor_utility_sources
++    PUBLIC_INCLUDE_DIRECTORIES
++      ${Python3_INCLUDE_DIRS}
++      ${TORCH_INCLUDE_DIRS}
++    PUBLIC_LINK_LIBRARIES
++      Eigen3::Eigen
++      pybind11::pybind11_headers
++      Python3::Module
++      ${TORCH_LIBRARIES}
++    PRIVATE_LINK_LIBRARIES
++      momentum
++    PUBLIC_COMPILE_OPTIONS
++      ${TORCH_CXX_FLAGS}
++    NO_INSTALL
++  )
++endif()
+ 
+ mt_library(
+   NAME python_utility
+@@ -132,55 +141,57 @@
+   NO_INSTALL
+ )
+ 
+-mt_library(
+-  NAME tensor_momentum
+-  PYMOMENTUM_HEADERS_VARS tensor_momentum_public_headers
+-  PYMOMENTUM_SOURCES_VARS tensor_momentum_sources
+-  PUBLIC_INCLUDE_DIRECTORIES
+-    ${ATEN_INCLUDE_DIR}
+-  PRIVATE_INCLUDE_DIRECTORIES
+-    ${TORCH_INCLUDE_DIRS}
+-  PUBLIC_LINK_LIBRARIES
+-    momentum
+-    diff_ik
+-    torch_bridge
+-    ${ATEN_LIBRARIES}
+-    pybind11::pybind11
+-  PRIVATE_LINK_LIBRARIES
+-    axel
+-    python_utility
+-    tensor_utility
+-    Ceres::ceres
+-    Dispenso::dispenso
+-    Eigen3::Eigen
+-    ${TORCH_LIBRARIES}
+-    ${torch_python}
+-  PUBLIC_COMPILE_OPTIONS
+-    ${TORCH_CXX_FLAGS}
+-  NO_INSTALL
+-)
++if(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++  mt_library(
++    NAME tensor_momentum
++    PYMOMENTUM_HEADERS_VARS tensor_momentum_public_headers
++    PYMOMENTUM_SOURCES_VARS tensor_momentum_sources
++    PUBLIC_INCLUDE_DIRECTORIES
++      ${ATEN_INCLUDE_DIR}
++    PRIVATE_INCLUDE_DIRECTORIES
++      ${TORCH_INCLUDE_DIRS}
++    PUBLIC_LINK_LIBRARIES
++      momentum
++      diff_ik
++      torch_bridge
++      ${ATEN_LIBRARIES}
++      pybind11::pybind11
++    PRIVATE_LINK_LIBRARIES
++      axel
++      python_utility
++      tensor_utility
++      Ceres::ceres
++      Dispenso::dispenso
++      Eigen3::Eigen
++      ${TORCH_LIBRARIES}
++      ${torch_python}
++    PUBLIC_COMPILE_OPTIONS
++      ${TORCH_CXX_FLAGS}
++    NO_INSTALL
++  )
+ 
+-mt_library(
+-  NAME tensor_ik
+-  PYMOMENTUM_HEADERS_VARS tensor_ik_public_headers
+-  PYMOMENTUM_SOURCES_VARS tensor_ik_sources
+-  PUBLIC_INCLUDE_DIRECTORIES
+-    ${ATEN_INCLUDE_DIR}
+-    ${TORCH_INCLUDE_DIRS}
+-  PUBLIC_LINK_LIBRARIES
+-    momentum
+-    diff_ik
+-    ${ATEN_LIBRARIES}
+-  PRIVATE_LINK_LIBRARIES
+-    tensor_utility
+-    Dispenso::dispenso
+-    Eigen3::Eigen
+-    ${TORCH_LIBRARIES}
+-    ${torch_python}
+-  PUBLIC_COMPILE_OPTIONS
+-    ${TORCH_CXX_FLAGS}
+-  NO_INSTALL
+-)
++  mt_library(
++    NAME tensor_ik
++    PYMOMENTUM_HEADERS_VARS tensor_ik_public_headers
++    PYMOMENTUM_SOURCES_VARS tensor_ik_sources
++    PUBLIC_INCLUDE_DIRECTORIES
++      ${ATEN_INCLUDE_DIR}
++      ${TORCH_INCLUDE_DIRS}
++    PUBLIC_LINK_LIBRARIES
++      momentum
++      diff_ik
++      ${ATEN_LIBRARIES}
++    PRIVATE_LINK_LIBRARIES
++      tensor_utility
++      Dispenso::dispenso
++      Eigen3::Eigen
++      ${TORCH_LIBRARIES}
++      ${torch_python}
++    PUBLIC_COMPILE_OPTIONS
++      ${TORCH_CXX_FLAGS}
++    NO_INSTALL
++  )
++endif()
+ 
+ mt_python_binding(
+   NAME geometry
+@@ -222,49 +233,51 @@
+     math
+ )
+ 
+-mt_python_binding(
+-  NAME diff_geometry
+-  PYMOMENTUM_HEADERS_VARS diff_geometry_public_headers
+-  PYMOMENTUM_SOURCES_VARS diff_geometry_sources
+-  INCLUDE_DIRECTORIES
+-    ${ATEN_INCLUDE_DIR}
+-    ${TORCH_INCLUDE_DIRS}
+-  LINK_LIBRARIES
+-    character
+-    tensor_momentum
+-    tensor_utility
+-    torch_bridge
+-    ${ATEN_LIBRARIES}
+-    ${TORCH_LIBRARIES}
+-    ${torch_python}
+-  COMPILE_OPTIONS
+-    ${TORCH_CXX_FLAGS}
+-)
++if(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++  mt_python_binding(
++    NAME diff_geometry
++    PYMOMENTUM_HEADERS_VARS diff_geometry_public_headers
++    PYMOMENTUM_SOURCES_VARS diff_geometry_sources
++    INCLUDE_DIRECTORIES
++      ${ATEN_INCLUDE_DIR}
++      ${TORCH_INCLUDE_DIRS}
++    LINK_LIBRARIES
++      character
++      tensor_momentum
++      tensor_utility
++      torch_bridge
++      ${ATEN_LIBRARIES}
++      ${TORCH_LIBRARIES}
++      ${torch_python}
++    COMPILE_OPTIONS
++      ${TORCH_CXX_FLAGS}
++  )
+ 
+-# Use 'pymomentum_solver' to avoid conflicts with the solver module
+-mt_python_binding(
+-  NAME pymomentum_solver
+-  MODULE_NAME solver
+-  PYMOMENTUM_HEADERS_VARS solver_public_headers
+-  PYMOMENTUM_SOURCES_VARS solver_sources
+-  INCLUDE_DIRECTORIES
+-    ${ATEN_INCLUDE_DIR}
+-    ${TORCH_INCLUDE_DIRS}
+-  LINK_LIBRARIES
+-    character_solver
+-    math
+-    skeleton
+-    python_utility
+-    tensor_ik
+-    tensor_momentum
+-    tensor_utility
+-    torch_bridge
+-    ${ATEN_LIBRARIES}
+-    ${TORCH_LIBRARIES}
+-    ${torch_python}
+-  COMPILE_OPTIONS
+-    ${TORCH_CXX_FLAGS}
+-)
++  # Use 'pymomentum_solver' to avoid conflicts with the solver module
++  mt_python_binding(
++    NAME pymomentum_solver
++    MODULE_NAME solver
++    PYMOMENTUM_HEADERS_VARS solver_public_headers
++    PYMOMENTUM_SOURCES_VARS solver_sources
++    INCLUDE_DIRECTORIES
++      ${ATEN_INCLUDE_DIR}
++      ${TORCH_INCLUDE_DIRS}
++    LINK_LIBRARIES
++      character_solver
++      math
++      skeleton
++      python_utility
++      tensor_ik
++      tensor_momentum
++      tensor_utility
++      torch_bridge
++      ${ATEN_LIBRARIES}
++      ${TORCH_LIBRARIES}
++      ${torch_python}
++    COMPILE_OPTIONS
++      ${TORCH_CXX_FLAGS}
++  )
++endif()
+ 
+ mt_python_binding(
+   NAME solver2
+@@ -294,24 +307,26 @@
+     python_utility
+ )
+ 
+-mt_python_binding(
+-  NAME pymomentum_axel
+-  MODULE_NAME axel
+-  PYMOMENTUM_HEADERS_VARS axel_public_headers
+-  PYMOMENTUM_SOURCES_VARS axel_sources
+-  INCLUDE_DIRECTORIES
+-    ${ATEN_INCLUDE_DIR}
+-    ${TORCH_INCLUDE_DIRS}
+-  LINK_LIBRARIES
+-    axel
+-    python_utility
+-    tensor_utility
+-    ${ATEN_LIBRARIES}
+-    ${TORCH_LIBRARIES}
+-    ${torch_python}
+-  COMPILE_OPTIONS
+-    ${TORCH_CXX_FLAGS}
+-)
++if(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++  mt_python_binding(
++    NAME pymomentum_axel
++    MODULE_NAME axel
++    PYMOMENTUM_HEADERS_VARS axel_public_headers
++    PYMOMENTUM_SOURCES_VARS axel_sources
++    INCLUDE_DIRECTORIES
++      ${ATEN_INCLUDE_DIR}
++      ${TORCH_INCLUDE_DIRS}
++    LINK_LIBRARIES
++      axel
++      python_utility
++      tensor_utility
++      ${ATEN_LIBRARIES}
++      ${TORCH_LIBRARIES}
++      ${torch_python}
++    COMPILE_OPTIONS
++      ${TORCH_CXX_FLAGS}
++  )
++endif()
+ 
+ mt_python_binding(
+   NAME pymomentum_camera
+@@ -437,23 +452,25 @@
+     endif()
+   endif()
+ 
+-  mt_test(
+-    NAME tensor_utility_test
+-    PYMOMENTUM_SOURCES_VARS tensor_utility_test_sources
+-    LINK_LIBRARIES
+-      tensor_utility
+-      Python3::Python
+-  )
++  if(MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS)
++    mt_test(
++      NAME tensor_utility_test
++      PYMOMENTUM_SOURCES_VARS tensor_utility_test_sources
++      LINK_LIBRARIES
++        tensor_utility
++        Python3::Python
++    )
+ 
+-  mt_test(
+-    NAME tensor_ik_test
+-    PYMOMENTUM_SOURCES_VARS tensor_ik_test_sources
+-    LINK_LIBRARIES
+-      character_test_helpers
+-      tensor_ik
+-      tensor_utility
+-      Python3::Python
+-  )
++    mt_test(
++      NAME tensor_ik_test
++      PYMOMENTUM_SOURCES_VARS tensor_ik_test_sources
++      LINK_LIBRARIES
++        character_test_helpers
++        tensor_ik
++        tensor_utility
++        Python3::Python
++    )
++  endif()
+ endif()
+ 
+ #===============================================================================


### PR DESCRIPTION
## Summary
- keep the existing `pymomentum` output as the full/backwards-compatible package
- add a CPU-built `pymomentum-core` output for downstreams that need core PyMomentum modules without USD, native renderer, native C++ Rerun runtime, Kokkos, or Torch C++ extension modules
- make core build with `MOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS=OFF`, so it omits `pymomentum.diff_geometry`, legacy `pymomentum.solver`, and this release's Torch-C++ backed `pymomentum.axel`; full `pymomentum` still keeps those modules
- keep `pymomentum-core` and full `pymomentum` from forcing a CPU PyTorch runtime, so downstreams such as MHR can still request or resolve a CUDA PyTorch runtime for their pure-PyTorch GPU paths
- constrain CPU build/host native deps so non-CUDA variants do not solve CUDA Ceres/Dr.Jit/Kokkos/Torch packages during CMake configure
- add default-on CMake options for native Rerun and PyMomentum Torch C++ extensions, used only by the trimmed core build
- make `pymomentum` and `pymomentum-core` mutually exclusive because both install the `pymomentum` namespace

Refs facebookresearch/MHR#40.

## Notes
- Naming: chose `pymomentum-core` instead of `pymomentum-full` because existing `pymomentum` remains the full package. `-core` is a common conda-forge split-package suffix, while `-full` is rare and would mostly be an alias here.
- Visualization: core keeps the pure Python visualization modules importable, but does not force optional `rerun-sdk`/`viser` or native renderer/USD/native C++ Rerun deps into downstream runtime environments.
- MHR packaging follow-up: MHR uses PyMomentum geometry plus pure-Python Torch helpers and PyTorch GPU inference paths. It does not appear to need both native `pymomentum-cpu` and `pymomentum-gpu`; once this output exists, the feedstock should depend on `pymomentum-core` while keeping `pytorch` unrestricted.
- mdspan: separate follow-up. The conda-forge convention for unreleased snapshots is a same-name `mdspan` dev/pre-release build on a label such as `conda-forge/label/mdspan_dev`, not a separately named `mdspan-dev` package.
- Recipe format: left this PR on v0 `meta.yaml`. A v1 `recipe.yaml` conversion would be broad churn in a CUDA/platform recipe and should be handled separately.

## Validation
- `git diff --check`
- `bash -n recipe/build_cpp.sh recipe/build_py.sh recipe/build_py_core.sh`
- `conda-smithy recipe-lint --conda-forge recipe`
  - existing suggestions only: `pymomentum-gpu` and aggregate `momentum` outputs do not have tests
- `git apply --check` for the new Momentum source patch against the patched `v0.1.110` source
- CMake configure check with `-DMOMENTUM_BUILD_PYMOMENTUM=ON -DMOMENTUM_BUILD_PYMOMENTUM_TORCH_EXTENSIONS=OFF -DMOMENTUM_BUILD_RENDERER=OFF -DMOMENTUM_BUILD_RERUN=OFF`
  - configured successfully
  - configure log showed no Torch/ATen lookup
  - generated target list had no `diff_geometry`, legacy `solver`, `axel`, or tensor bridge targets
- `pixi run conda-render -n -m .ci_support/linux_64_cuda_compiler_versionNone.yaml --python 3.12 -c conda-forge recipe`
  - rendered `pymomentum-core` host has no `pytorch` or `libtorch`
  - rendered `pymomentum-core` runtime has `pytorch` only for pure-Python Torch helpers, without explicit `libtorch` pinning
  - rendered `pymomentum-core` tests exclude the Torch-C++ backed modules and assert they are absent
- `pixi run conda-render -n -m .ci_support/linux_64_cuda_compiler_version12.9.yaml --python 3.12 -c conda-forge recipe`
  - rendered CUDA `pymomentum` still uses CUDA Kokkos/PyTorch/libtorch variants and still tests `diff_geometry` and legacy `solver`
- `pixi run conda-build --output -m .ci_support/linux_64_cuda_compiler_versionNone.yaml --python 3.12 -c conda-forge recipe`
- `pixi run conda-build --output -m .ci_support/linux_64_cuda_compiler_version12.9.yaml --python 3.12 -c conda-forge recipe`
