### PR TITLE
Enable linux-aarch64 builds

### DIFF
--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9python3.12.____cpython.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9python3.13.____cp313.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.9python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.9python3.14.____cp314.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_version13.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version13.0python3.12.____cpython.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_version13.0python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version13.0python3.13.____cp313.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_version13.0python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version13.0python3.14.____cp314.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '13.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314.yaml
@@ -1,0 +1,57 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '12.1'
+libboost_devel:
+- '1.88'
+librerun_sdk:
+- 0.32.2
+libtorch:
+- '2.10'
+numpy:
+- '2'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+pytorch:
+- '2.10'
+re2:
+- 2025.11.05
+spdlog:
+- '1.17'
+target_platform:
+- linux-aarch64
+tbb_devel:
+- '2022'
+urdfdom:
+- '5.1'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - c_stdlib_version
+  - cuda_compiler_version
+zlib:
+- '1'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -103,6 +103,87 @@ jobs:
             tools_install_dir: ~/miniforge3
             build_workspace_dir: build_artifacts
             docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_version12.9python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_version12.9python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_version12.9python3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_version13.0python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_version13.0python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_version13.0python3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+          - CONFIG: linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['ubuntu-latest']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,12 +1,9 @@
 azure:
   free_disk_space: true
-  settings_win:
-    variables:
-      CONDA_BLD_PATH: C:\\bld\\
-      MINIFORGE_HOME: C:\Miniforge
 bot:
   automerge: true
 build_platform:
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   error_overlinking: true
@@ -16,4 +13,15 @@ conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main
+provider:
+  linux_aarch64: default
 test: native_and_emulated
+workflow_settings:
+  build_workspace_dir:
+    - provider: azure
+      os: win
+      value: C:\\bld\\
+  tools_install_dir:
+    - provider: azure
+      os: win
+      value: C:\Miniforge

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "3.62.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/momentum-feedstock"
 authors = ["@conda-forge/momentum"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [dependencies]
@@ -77,6 +77,60 @@ description = "Build momentum-feedstock with variant linux_64_cuda_compiler_vers
 [tasks."inspect-linux_64_cuda_compiler_versionNonepython3.14.____cp314"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_cuda_compiler_versionNonepython3.14.____cp314.yaml"
 description = "List contents of momentum-feedstock packages built for variant linux_64_cuda_compiler_versionNonepython3.14.____cp314"
+[tasks."build-linux_aarch64_cuda_compiler_version12.9python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version12.9python3.12.____cpython.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_version12.9python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_version12.9python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_version12.9python3.12.____cpython.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_version12.9python3.12.____cpython"
+[tasks."build-linux_aarch64_cuda_compiler_version12.9python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version12.9python3.13.____cp313.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_version12.9python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_version12.9python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_version12.9python3.13.____cp313.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_version12.9python3.13.____cp313"
+[tasks."build-linux_aarch64_cuda_compiler_version12.9python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version12.9python3.14.____cp314.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_version12.9python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_version12.9python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_version12.9python3.14.____cp314.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_version12.9python3.14.____cp314"
+[tasks."build-linux_aarch64_cuda_compiler_version13.0python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.12.____cpython.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_version13.0python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_version13.0python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.12.____cpython.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_version13.0python3.12.____cpython"
+[tasks."build-linux_aarch64_cuda_compiler_version13.0python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.13.____cp313.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_version13.0python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_version13.0python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.13.____cp313.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_version13.0python3.13.____cp313"
+[tasks."build-linux_aarch64_cuda_compiler_version13.0python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.14.____cp314.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_version13.0python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_version13.0python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.14.____cp314.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_version13.0python3.14.____cp314"
+[tasks."build-linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython"
+[tasks."build-linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_versionNonepython3.13.____cp313"
+[tasks."build-linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314.yaml"
+description = "Build momentum-feedstock with variant linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314.yaml"
+description = "List contents of momentum-feedstock packages built for variant linux_aarch64_cuda_compiler_versionNonepython3.14.____cp314"
 [tasks."build-osx_64_python3.12.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.12.____cpython.yaml"
 description = "Build momentum-feedstock with variant osx_64_python3.12.____cpython directly (without setup scripts)"


### PR DESCRIPTION
Summary:
- Enable linux-aarch64 builds for momentum.
- Rerender the feedstock, adding CPU, CUDA 12.9, and CUDA 13.0 linux-aarch64 variants for Python 3.12-3.14.
- Move the existing Azure Windows C: path override from deprecated settings_win variables to workflow_settings.

Checks:
- pixi run -e smithy rerender
- pixi run -e smithy lint
- pixi run rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_versionNonepython3.12.____cpython.yaml --target-platform linux-aarch64 --render-only
- pixi run rattler-build build --recipe recipe -m .ci_support/linux_aarch64_cuda_compiler_version13.0python3.12.____cpython.yaml --target-platform linux-aarch64 --render-only

I also checked that current conda-forge pytorch/libtorch 2.10 packages exist for linux-aarch64 CPU, CUDA 12.9, and CUDA 13.0. Full build/test coverage is left to feedstock CI.