### PR TITLE
Split PyMomentum conda outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-momentum-green.svg)](https://anaconda.org/conda-forge/momentum) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/momentum.svg)](https://anaconda.org/conda-forge/momentum) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/momentum.svg)](https://anaconda.org/conda-forge/momentum) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/momentum.svg)](https://anaconda.org/conda-forge/momentum) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-momentum--cpp-green.svg)](https://anaconda.org/conda-forge/momentum-cpp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/momentum-cpp.svg)](https://anaconda.org/conda-forge/momentum-cpp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/momentum-cpp.svg)](https://anaconda.org/conda-forge/momentum-cpp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/momentum-cpp.svg)](https://anaconda.org/conda-forge/momentum-cpp) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pymomentum-green.svg)](https://anaconda.org/conda-forge/pymomentum) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pymomentum.svg)](https://anaconda.org/conda-forge/pymomentum) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pymomentum.svg)](https://anaconda.org/conda-forge/pymomentum) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pymomentum.svg)](https://anaconda.org/conda-forge/pymomentum) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pymomentum--core-green.svg)](https://anaconda.org/conda-forge/pymomentum-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pymomentum-core.svg)](https://anaconda.org/conda-forge/pymomentum-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pymomentum-core.svg)](https://anaconda.org/conda-forge/pymomentum-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pymomentum-core.svg)](https://anaconda.org/conda-forge/pymomentum-core) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pymomentum--cpu-green.svg)](https://anaconda.org/conda-forge/pymomentum-cpu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pymomentum-cpu.svg)](https://anaconda.org/conda-forge/pymomentum-cpu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pymomentum-cpu.svg)](https://anaconda.org/conda-forge/pymomentum-cpu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pymomentum-cpu.svg)](https://anaconda.org/conda-forge/pymomentum-cpu) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pymomentum--gpu-green.svg)](https://anaconda.org/conda-forge/pymomentum-gpu) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pymomentum-gpu.svg)](https://anaconda.org/conda-forge/pymomentum-gpu) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pymomentum-gpu.svg)](https://anaconda.org/conda-forge/pymomentum-gpu) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pymomentum-gpu.svg)](https://anaconda.org/conda-forge/pymomentum-gpu) |
 
@@ -150,16 +151,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `momentum, momentum-cpp, pymomentum, pymomentum-cpu, pymomentum-gpu` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `momentum, momentum-cpp, pymomentum, pymomentum-core, pymomentum-cpu, pymomentum-gpu` can be installed with `conda`:
 
 ```
-conda install momentum momentum-cpp pymomentum pymomentum-cpu pymomentum-gpu
+conda install momentum momentum-cpp pymomentum pymomentum-core pymomentum-cpu pymomentum-gpu
 ```
 
 or with `mamba`:
 
 ```
-mamba install momentum momentum-cpp pymomentum pymomentum-cpu pymomentum-gpu
+mamba install momentum momentum-cpp pymomentum pymomentum-core pymomentum-cpu pymomentum-gpu
 ```
 
 It is possible to list all of the versions of `momentum` available on your platform with `conda`:

--- a/recipe/bld_py.bat
+++ b/recipe/bld_py.bat
@@ -1,6 +1,9 @@
 @echo on
 setlocal EnableExtensions EnableDelayedExpansion
 
+if not defined MOMENTUM_BUILD_TORCH_EXTENSIONS set MOMENTUM_BUILD_TORCH_EXTENSIONS=ON
+echo MOMENTUM_BUILD_TORCH_EXTENSIONS=%MOMENTUM_BUILD_TORCH_EXTENSIONS%
+
 rem ------------------------------------------------------------------
 rem  Detect CUDA build
 rem  CUDA_COMPILER_VERSION is set by conda-build; "None" means CPU build
@@ -25,7 +28,9 @@ cd /d %SRC_DIR%
 
 if %IS_CUDA_BUILD%==0 (
     echo Using pip install for CPU build...
+    if exist build rmdir /s /q build
     set CMAKE_ARGS=%CMAKE_ARGS% ^
+        -DMOMENTUM_BUILD_TORCH_EXTENSIONS=%MOMENTUM_BUILD_TORCH_EXTENSIONS% ^
         -DMOMENTUM_BUILD_IO_USD=OFF ^
         -DMOMENTUM_BUILD_RENDERER=ON ^
         -DMOMENTUM_BUILD_TESTING=OFF ^
@@ -87,6 +92,7 @@ cmake .. -G Ninja ^
     -DPython3_EXECUTABLE="%PYTHON%" ^
     -DCMAKE_CUDA_HOST_COMPILER="%CMAKE_CUDA_HOST_COMPILER%" ^
     -DMOMENTUM_BUILD_PYMOMENTUM=ON ^
+    -DMOMENTUM_BUILD_TORCH_EXTENSIONS=%MOMENTUM_BUILD_TORCH_EXTENSIONS% ^
     -DMOMENTUM_BUILD_IO_USD=OFF ^
     -DMOMENTUM_BUILD_RENDERER=ON ^
     -DMOMENTUM_BUILD_TESTING=OFF ^

--- a/recipe/build_py.sh
+++ b/recipe/build_py.sh
@@ -2,6 +2,8 @@
 
 set -exo pipefail
 
+: "${MOMENTUM_BUILD_TORCH_EXTENSIONS:=ON}"
+
 # Workaround for PyTorch 2.9 CMake config issue on Unix:
 # The pytorch package's TorchConfig.cmake references include directories like
 # "torch/include/torch/csrc/api/include" that don't exist. The libtorch package
@@ -43,6 +45,7 @@ else
 fi
 
 export CMAKE_ARGS="$CMAKE_ARGS \
+    -DMOMENTUM_BUILD_TORCH_EXTENSIONS=$MOMENTUM_BUILD_TORCH_EXTENSIONS \
     -DMOMENTUM_BUILD_RENDERER=$MOMENTUM_BUILD_RENDERER \
     -DMOMENTUM_BUILD_TESTING=OFF \
     -DMOMENTUM_ENABLE_SIMD=OFF \
@@ -64,5 +67,7 @@ elif [[ ! -d "${PREFIX}/include/pxr" ]]; then
   # openusd is not available (check for pxr headers)
   export CMAKE_ARGS="$CMAKE_ARGS -DMOMENTUM_BUILD_IO_USD=OFF"
 fi
+
+rm -rf build
 
 $PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: momentum
   version: "0.1.111"
-  build_number: 1
+  build_number: 2
 
 recipe:
   name: ${{ name|lower }}-split
@@ -132,12 +132,135 @@ outputs:
           - urdf_viewer --help
 
   - package:
-      name: pymomentum
+      name: pymomentum-core
+    build:
+      skip:
+        - cuda_compiler_version != "None"
+      string: ${{ "core_py" ~ (python | version_to_buildstring) ~ "_h" ~ hash ~ "_" ~ build_number }}
+      script:
+        file: ${{ "bld_py.bat" if win else "build_py.sh" }}
+        env:
+          MOMENTUM_BUILD_TORCH_EXTENSIONS: "OFF"
+      # Internal DLLs bundled together that reference each other
+      dynamic_linking:
+        missing_dso_allowlist:
+          - if: win
+            then:
+              - "*/momentum_*.dll"
+              - "*/axel.dll"
+    requirements:
+      build:
+        - ${{ compiler("cxx") }}
+        - ${{ stdlib("c") }}
+        - cmake
+        - if: build_platform != target_platform
+          then: cross-python_${{ target_platform }}
+        - gtest
+        - indicators
+        - libboost-devel
+        - make
+        - ninja
+        - pip
+        - pybind11-abi ==11
+        - python
+        - scikit-build-core >=0.11
+      host:
+        - ceres-solver * cpu*
+        - cli11
+        - dispenso
+        - drjit-cpp * cpu*
+        # Momentum 0.1.111 requires Eigen 5.0.x.
+        - eigen >=5.0,<5.1
+        - ezc3d
+        - fmt
+        - fx-gltf
+        - indicators
+        - mdspan >=0.6.1.dev20260223
+        - librerun-sdk
+        - ms-gsl
+        - nlohmann_json
+        - numpy
+        - openfbx
+        - if: linux
+          then: openusd
+        - pip
+        - pytest
+        - python
+        - re2
+        - scikit-build-core >=0.11
+        - spdlog
+        - if: not win
+          then: tbb-devel
+        - urdfdom
+        - zlib
+      run:
+        - ezc3d
+        - dispenso
+        - if: win
+          then:
+            - drjit-cpp * cpu*
+            - fmt
+        - gflags
+        - indicators
+        - if: osx
+          then: libabseil
+        - libdeflate
+        - if: win
+          then: librerun-sdk
+        # Direct DSOs used by the Python extensions; host run exports do not
+        # cover all of these in the CUDA build.
+        - if: linux
+          then:
+            - libgcc
+            - libstdcxx
+        - if: linux or win
+          then: libre2-11
+        - numpy
+        - python ${{ python }}
+        - python_abi * *_cp${{ python | version_to_buildstring }}
+        - pytorch >=1.13
+        - scipy >=1.7
+        - spdlog
+        - if: linux
+          then: tbb
+        - urdfdom
+        - if: win
+          then:
+            - ucrt
+            - vc14_runtime
+      run_constraints:
+        - pymomentum <0a0
+        - pymomentum-cpu <0a0
+        - pymomentum-gpu <0a0
+    tests:
+      - requirements:
+          run:
+            - pip
+        script:
+          - pip list
+          - python -c "import pymomentum.axel"
+          - python -c "import pymomentum.backend"
+          - python -c "import pymomentum.geometry"
+          - python -c "import pymomentum.marker_tracking"
+          - python -c "import pymomentum.quaternion"
+          - python -c "import pymomentum.renderer"
+          - python -c "import pymomentum.skel_state"
+          - python -c "import pymomentum.solver2"
+          - python -c "import torch; import pymomentum.torch.character"
+          - python -c "import pymomentum.trs"
+          - python -c "import importlib.util; assert importlib.util.find_spec('pymomentum.diff_geometry') is None"
+          - python -c "import importlib.util; assert importlib.util.find_spec('pymomentum.solver') is None"
+          - pip check
+
+  - package:
+      name: ${{ "pymomentum-gpu" if cuda_compiler_version != "None" else "pymomentum-cpu" }}
     build:
       string: ${{ "cuda" ~ (cuda_compiler_version | replace(".", "")) ~ "_py" ~ (python | version_to_buildstring) ~ "_pt" ~ (pytorch | replace(".", "")) ~ "_h" ~ hash ~ "_" ~ build_number if cuda_compiler_version != "None" else "cpu_py" ~ (python | version_to_buildstring) ~ "_pt" ~ (pytorch | replace(".", "")) ~ "_h" ~
         hash ~ "_" ~ build_number }}
       script:
         file: ${{ "bld_py.bat" if win else "build_py.sh" }}
+        env:
+          MOMENTUM_BUILD_TORCH_EXTENSIONS: "ON"
       # Internal DLLs bundled together that reference each other
       dynamic_linking:
         missing_dso_allowlist:
@@ -271,6 +394,7 @@ outputs:
         - numpy
         - python ${{ python }}
         - python_abi * *_cp${{ python | version_to_buildstring }}
+        - scipy >=1.7
         - spdlog
         - if: linux
           then: tbb
@@ -279,6 +403,11 @@ outputs:
           then:
             - ucrt
             - vc14_runtime
+      run_constraints:
+        - pymomentum-core <0a0
+        - if: cuda_compiler_version != "None"
+          then: pymomentum-cpu <0a0
+          else: pymomentum-gpu <0a0
     tests:
       - requirements:
           run:
@@ -305,13 +434,15 @@ outputs:
           - pip check
 
   - package:
-      name: ${{ "pymomentum-gpu" if cuda_compiler_version != "None" else "pymomentum-cpu" }}
+      name: pymomentum
     build:
       string: ${{ "cuda" ~ (cuda_compiler_version | replace(".", "")) ~ "_py" ~ (python | version_to_buildstring) ~ "_pt" ~ (pytorch | replace(".", "")) ~ "_h" ~ hash ~ "_" ~ build_number if cuda_compiler_version != "None" else "cpu_py" ~ (python | version_to_buildstring) ~ "_pt" ~ (pytorch | replace(".", "")) ~ "_h" ~
         hash ~ "_" ~ build_number }}
     requirements:
       run:
-        - ${{ pin_subpackage("pymomentum", exact=True) }}
+        - if: cuda_compiler_version != "None"
+          then: ${{ pin_subpackage("pymomentum-gpu", exact=True) }}
+          else: ${{ pin_subpackage("pymomentum-cpu", exact=True) }}
     tests:
       - requirements:
           run:
@@ -329,7 +460,7 @@ outputs:
     requirements:
       run:
         - ${{ pin_subpackage("momentum-cpp", exact=True) }}
-        - ${{ pin_subpackage("pymomentum", exact=True) }}
+        - ${{ pin_subpackage("pymomentum-cpu", exact=True) }}
         - python
       run_exports:
         - ${{ pin_subpackage("momentum-cpp", upper_bound="x.x") }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -185,6 +185,7 @@ outputs:
           then: openusd
         - pip
         - pytest
+        - pybind11
         - python
         - re2
         - scikit-build-core >=0.11
@@ -337,6 +338,7 @@ outputs:
           then: openusd
         - pip
         - pytest
+        - pybind11
         - python
         - if: cuda_compiler_version == "None"
           then:


### PR DESCRIPTION
## Motivation

Upstream split the PyPI wheels in facebookresearch/momentum#1483:

- `pymomentum-core` contains the core Python modules without the Torch C++ extension modules.
- `pymomentum-cpu` and `pymomentum-gpu` contain the full package, including `pymomentum.diff_geometry` and `pymomentum.solver`, linked against the relevant PyTorch ABI.

facebookresearch/momentum#1523 then updated the core wheel runtime deps/extras, and facebookresearch/momentum#1503 documents the public package split and notes that conda/pixi still publish full PyMomentum today.

conda-forge currently publishes the full `pymomentum` artifact, while `pymomentum-cpu` and `pymomentum-gpu` are compatibility metapackages pointing back to it. `pymomentum-core` is not published. This PR mirrors the upstream package model on conda-forge while keeping existing `pymomentum` installs working.

## Output registration

- `pymomentum-cpu` and `pymomentum-gpu` were already registered as outputs for `momentum-feedstock` in conda-forge/admin-requests#1137.
- `pymomentum-core` is the only new output added here, and it was registered in conda-forge/admin-requests#2165.
- Current-head CI passes output validation with all three output names.

## Changes

- Add a real `pymomentum-core` output built with `MOMENTUM_BUILD_TORCH_EXTENSIONS=OFF`.
- Build real `pymomentum-cpu` / `pymomentum-gpu` outputs with `MOMENTUM_BUILD_TORCH_EXTENSIONS=ON`.
- Keep `pymomentum` as a compatibility metapackage that depends on the appropriate full output.
- Make the aggregate `momentum` package depend on the real CPU Python output.
- Add mutually exclusive run constraints between `pymomentum-core`, `pymomentum-cpu`, and `pymomentum-gpu`, since they install the same `pymomentum` namespace.
- Add `scipy` to the Python runtime deps to match upstream PyPI metadata.
- Add upstream-declared `pybind11` as a Python-extension build dependency.
- Add smoke tests for the core output, including assertions that `pymomentum.diff_geometry` and `pymomentum.solver` are not exposed there.

## Validation

- `conda-smithy recipe-lint --conda-forge --feedstock-dir . recipe`
- `conda-smithy rerender --check --feedstock_directory .`
- `rattler-build build -r recipe --render-only -m .ci_support/linux_64_cuda_compiler_versionNonepython3.12.____cpython.yaml --target-platform linux-64`
- `rattler-build build -r recipe --render-only -m .ci_support/linux_64_cuda_compiler_version13.0python3.12.____cpython.yaml --target-platform linux-64`
- `rattler-build build -r recipe --render-only -m .ci_support/win_64_cuda_compiler_versionNonepython3.12.____cpython.yaml --target-platform win-64`
- `rattler-build build -r recipe --render-only -m .ci_support/osx_arm64_python3.12.____cpython.yaml --target-platform osx-arm64`
- Current-head CI is green on `e30ebe9`.

I did not run a full local package build.
