### PR TITLE
Rebuild momentum 0.1.113

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: momentum
   version: "0.1.113"
-  build_number: 0
+  build_number: 1
 
 recipe:
   name: ${{ name|lower }}-split


### PR DESCRIPTION
Post-merge Azure CI for #303 failed only on `osx_64_python3.13` while fetching `mpmath` from conda-forge:

`stream closed because of a broken pipe`

The recipe itself passed pre-merge CI, and the failed osx-64 Python 3.13 artifacts are missing from conda-forge while the adjacent 3.12/3.14 artifacts exist. This bumps the build number to publish a complete 0.1.113 build set.

Validation:
- `conda-smithy recipe-lint .`
- render-only check produced the expected build-1 osx-64 Python 3.13 output names, then hit a local `rattler-build` channel-path panic before solving